### PR TITLE
Add some sugar for common REST errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 var typedError = require('typederror');
 
-module.exports.NotFound = typedError('NotFoundError', {code: 404});
 module.exports.Invalid = typedError('InvalidError', {code: 400});
+module.exports.Unauthorized = typedError('UnauthorizedError', {code: 401});
+module.exports.Forbidden = typedError('ForbiddenError', {code: 403});
+module.exports.NotFound = typedError('NotFoundError', {code: 404});
+module.exports.Conflict = typedError('ConflictError', {code: 409});
+module.exports.Gone = typedError('GoneError', {code: 410});
 module.exports.Err = typedError('Error', {code: 500});
 
 // for back-compat

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var typedError = require('typederror');
 
 module.exports.NotFound = typedError('NotFoundError', {code: 404});
-module.exports.NotAuthorized = typedError('NotAuthorizedError', {code: 403});
 module.exports.Invalid = typedError('InvalidError', {code: 400});
 module.exports.Err = typedError('Error', {code: 500});
+
+// for back-compat
+module.exports.NotAuthorized = typedError('NotAuthorizedError', {code: 403});


### PR DESCRIPTION
This PR adds support for a few REST errors used in scenarios where we are otherwise rolling custom TypedErrors:
- `401`
- `409`
- `410`

In addition, I added `.Forbidden` as a `403` generator. In order to provide back-compat support, `NotAuthorized` still generates a `403`. However, the similarly named `.Unauthorized` throws as a `401`  per [W3C naming](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
